### PR TITLE
Fix issue #16: Github Pagesへデプロイするワークフローのエラー対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allow write access to the repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request fixes #16.

The issue was a "Permission denied" error (403 Forbidden) when the GitHub Actions workflow tried to push to the `gh-pages` branch. This occurred because the default `GITHUB_TOKEN` used by the workflow lacked write permissions to the repository.

The fix involved adding the following lines to the `.github/workflows/deploy.yml` file within the `build_and_deploy` job:
```yaml
    permissions:
      contents: write # Allow write access to the repository
```
This change explicitly grants the `GITHUB_TOKEN` write access to the repository's contents for this job. With write access, the `git push` command executed by the workflow should now succeed, resolving the permission error.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌