### PR TITLE
Fix issue #23: カート画面の色合い修正

### DIFF
--- a/flutter_app/lib/widgets/cart_view.dart
+++ b/flutter_app/lib/widgets/cart_view.dart
@@ -16,7 +16,8 @@ class CartView extends ConsumerWidget {
 
     return Container(
       padding: const EdgeInsets.all(16.0),
-      color: Colors.grey[200],
+      // Use cardTheme color for background to match the menu screen style
+      color: Theme.of(context).cardTheme.color,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [


### PR DESCRIPTION
This pull request fixes #23.

The issue was that the `CartView` screen had a different color scheme compared to other screens, specifically the `MenuScreen`. The request was to unify these color schemes.

The provided patch changes the background color of the `CartView`'s main `Container`.
Specifically, the line `color: Colors.grey[200],` was replaced with `color: Theme.of(context).cardTheme.color,`.

This change directly addresses the issue by:
1.  Removing a hardcoded color (`Colors.grey[200]`) from `CartView`.
2.  Applying a theme-based color (`Theme.of(context).cardTheme.color`) for the `CartView` background.

The AI agent's explanation clarifies that this `cardTheme.color` is consistent with the `MenuScreen`'s card elements. By using the same theme attribute for the `CartView` background as (presumably) used by elements on the `MenuScreen`, the color schemes are unified. Additionally, the agent noted that `CartItemCard` (likely used within `CartView`) already uses the `Card` widget, which respects the global `cardTheme`, further contributing to consistency.

Therefore, the change successfully modifies `CartView` to use a theme-defined color that is intended to match the `MenuScreen`, resolving the color discrepancy.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌