### PR TITLE
Fix issue #36: カテゴリーフィルタボタンの文字切れ対策

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -134,6 +134,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen> { // Create State class
                           backgroundColor: const Color(0xFF5D4037), // Medium brown
                           selectedColor: const Color(0xFFA1887F), // Lighter brown for selected
                           labelStyle: const TextStyle(color: Color(0xFFEFEBE9)), // Light beige text
+                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap, // Ensure chip sizes to content
                         ),
                       ))
                   .toList(),


### PR DESCRIPTION
This pull request fixes #36.

The issue was that text on category filter buttons (`ChoiceChip` widgets) was being truncated. The requirement was to make the button width adjust dynamically based on the length of the text, so all text is visible.

The change made was adding the property `materialTapTargetSize: MaterialTapTargetSize.shrinkWrap` to the `ChoiceChip` widget in `flutter_app/lib/main.dart`.

This change is expected to resolve the issue. The `materialTapTargetSize` property influences how the chip defines its boundaries. By setting it to `MaterialTapTargetSize.shrinkWrap`, the chip's tap target (and often, consequently, its perceived boundary for layout purposes) is made to fit tightly around its actual content (the label, in this case). This contrasts with the default `padded` value, which might enforce a minimum tap target size (e.g., 48x48 pixels) by adding implicit padding if the content is smaller.

The AI agent's explanation states that this change "should allow the chip to dynamically adjust its width based on the length of the text label, preventing truncation" by "ensur[ing] chip sizes to content." If the previous `padded` behavior was somehow contributing to a fixed or inadequately calculated width for the text area within the chip, switching to `shrinkWrap` would allow the chip's width to be more directly determined by the label's text length. This would enable the chip to expand as needed to display longer text, fulfilling the requirement for dynamic width and preventing truncation.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌