### PR TITLE
Fix issue #44: e2e_tests.ymlの修正

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -27,7 +27,7 @@ jobs:
           BASE_URL: ${{ github.event.deployment_status.target_url }} # デプロイされたURLを環境変数として設定
         run: |
           cd flutter_app # flutter_appディレクトリに移動
-          npx cypress run --config video=true # 動画を記録してテストを実行
+          npx cypress run --config video=true,videosFolder=cypress/videos # 動画を記録してテストを実行
 
       - name: Upload test videos
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This pull request fixes #44.

The issue was that video files were not being stored in the `flutter_app/cypress/videos` directory after Cypress tests were run in the GitHub Actions workflow.

The change made in `.github/workflows/e2e_tests.yml` modifies the Cypress run command from `npx cypress run --config video=true` to `npx cypress run --config video=true,videosFolder=cypress/videos`.

This change explicitly tells Cypress to save the recorded videos into a folder named `cypress/videos` relative to the current working directory. Since the preceding step in the workflow is `cd flutter_app`, the `videosFolder=cypress/videos` configuration will result in videos being saved to `flutter_app/cypress/videos`.

This directly addresses the problem described, as it ensures Cypress saves the videos to the intended directory. The subsequent "Upload test videos" step, which uses `path: flutter_app/cypress/videos`, should then be able to find and upload these videos. Therefore, the change is expected to resolve the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌