### PR TITLE
Fix issue #43: カテゴリフィルターボタン内の文字が全て表示されるように修正をしてください。

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -121,20 +121,23 @@ class _MenuScreenState extends ConsumerState<MenuScreen> { // Create State class
               children: ['すべて', 'コーヒー', 'お茶', 'パスタ', 'サンドイッチ'] // Updated categories
                   .map((category) => Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                        child: ChoiceChip( // Changed to ChoiceChip for selection indication
-                          label: Text(category),
-                          selected: _selectedCategory == category, // Set selected state
-                          onSelected: (selected) { // Handle selection
+                        child: FilterChip(
+                          label: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                            child: Text(category),
+                          ),
+                          selected: _selectedCategory == category,
+                          onSelected: (selected) {
                             if (selected) {
                               setState(() {
                                 _selectedCategory = category;
                               });
                             }
                           },
-                          backgroundColor: const Color(0xFF5D4037), // Medium brown
-                          selectedColor: const Color(0xFFA1887F), // Lighter brown for selected
-                          labelStyle: const TextStyle(color: Color(0xFFEFEBE9)), // Light beige text
-                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap, // Ensure chip sizes to content
+                          backgroundColor: const Color(0xFF5D4037),
+                          selectedColor: const Color(0xFFA1887F),
+                          labelStyle: const TextStyle(color: Color(0xFFEFEBE9)),
+                          showCheckmark: false, // チェックマークを非表示にする
                         ),
                       ))
                   .toList(),


### PR DESCRIPTION
This pull request fixes #43.

The issue was that text within filter buttons was being cut off because the buttons did not resize based on the text length. The fix addresses this by replacing the `ChoiceChip` widgets with `FilterChip` widgets and, crucially, wrapping the `Text` label within a `Padding` widget. This adds horizontal padding around the text, forcing the chip to expand its width to accommodate the text and the padding. As a result, the button's width is now dynamically determined by the length of its text label, which resolves the issue of the text being truncated.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌